### PR TITLE
Add simple implementations for basic CA functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup, find_packages
+from setuptools import setup, find_packages
 
 setup(
     name='vouch',
@@ -12,11 +7,12 @@ setup(
     author='',
     author_email='',
     install_requires=[
-        'python-memcached',
+        'cryptography',
+        'keystonemiddleware',
         'Paste',
         'PasteDeploy',
         'pecan',
-        'keystonemiddleware'
+        'python-memcached'
     ],
     scripts=['bin/vouch'],
     test_suite='nose.collector',

--- a/vouch.conf
+++ b/vouch.conf
@@ -1,2 +1,20 @@
-key1: value1
-key2: value2
+# the backend used to handle certs. Currently ignored.
+backend: firkinize.vault.ca.VaultCA
+
+# http address of the vault cluster
+vault_addr: https://vault-dev.platform9.horse:8200
+
+# token with enough access to sign certs for the ca and role below
+vault_token: 48cded38-38a8-b273-eb5c-d2bba66d78c6
+
+# external address of the service, used in the version endpoint
+vouch_addr: http://10.1.10.210:8558
+
+# name of the CA managed by this signing service
+ca_name: bob-ca
+
+# common name for the ca cert
+ca_common_name: bob-test-root
+
+# role containing configuration for the signing ca
+signing_role: bob-hosts

--- a/vouch/controllers/root.py
+++ b/vouch/controllers/root.py
@@ -1,14 +1,18 @@
-from vouch.controllers.sign import SignController
+from vouch.controllers.v1 import V1Controller
+from pecan import expose
+from pecan.rest import RestController
 
-class V1Controller(object):
-    '''
-    Version 1 of the controller
-    '''
-    sign = SignController()
+from vouch.conf import CONF
 
-
-class RootController(object):
-    '''
-    Root controller class for the image library REST API
-    '''
+class RootController(RestController):
     v1 = V1Controller()
+
+    @expose('json')
+    def get(self):
+        """
+        Get links to the available versions
+        """
+        vouch_addr = CONF.get('vouch_addr', 'unknown')
+        return {
+            'v1': '%s/v1' % vouch_addr
+        }

--- a/vouch/controllers/sign.py
+++ b/vouch/controllers/sign.py
@@ -1,24 +1,105 @@
+
+# pylint: disable=too-few-public-methods
+
 import logging
 import pecan
+import requests
 
-from pecan.core import abort
-from pecan import expose, conf
-import os.path
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from pecan import expose
+from pecan.rest import RestController
 
-from pprint import pformat
 from vouch.conf import CONF
+from firkinize.vault.ca import VaultCA
 
 LOG = logging.getLogger(__name__)
 
-class SignController(object):
+class CAController(RestController):
     def __init__(self):
-        pass
+        self._vault = VaultCA(CONF['vault_addr'], CONF['vault_token'])
 
-    @expose(content_type=None) # any content type is ok - check type below
-    def _default(self, *path_elems):
-        LOG.info(pformat(vars(pecan.request)))
-        LOG.info(pformat(CONF))
-        pecan.response.content_type = 'application/text'
-        pecan.response.charset = None # defaults to UTF-8
-        pecan.response.status = 200
+    @expose('json')
+    def get(self):
+        """
+        GET /v1/sign/ca
+        Get the CA cert of the currently configured CA
+        """
+        ca_name = CONF['ca_name']
+        LOG.info('Fetching current ca certificate for %s.', ca_name)
+        try:
+            resp = self._vault.get_ca(ca_name)
+            pecan.response.status = 200
+            pecan.response.json = resp.json()['data']
+        except requests.HTTPError as e:
+            pecan.response.status = e.response.status_code
+            pecan.response.json = e.response.json()
         return pecan.response
+
+    @expose('json')
+    def post(self):
+        """
+        POST /v1/sign/ca
+        Generate a new CA root certificate. Returns the old one and the
+        new one.
+        """
+        resp_json = {}
+        ca_name = CONF['ca_name']
+        ca_common_name = CONF['ca_common_name']
+
+        LOG.info('Refreshing ca certificate for %s.', ca_name)
+        try:
+            resp_old = self._vault.get_ca(ca_name)
+            resp_json['previous'] = resp_old.json()['data']
+            resp_new = self._vault.new_ca_root(ca_name, ca_common_name)
+            resp_json['new'] = resp_new.json()['data']
+            pecan.response.status = 200
+            pecan.response.json = resp_json
+        except requests.HTTPError as e:
+            pecan.response.status = e.response.status_code
+            pecan.response.json = e.response.json()
+        return pecan.response
+
+
+class CertController(RestController):
+    def __init__(self):
+        self._vault = VaultCA(CONF['vault_addr'], CONF['vault_token'])
+
+    @expose('json')
+    def post(self):
+        """
+        POST /v1/sign/cert
+        Sign a CSR. Body should at least include the 'csr' attribute
+        containing a PEM encoded CSR. May also include a list of alt_names,
+        ip_sans, and a ttl (e.g. 780h)
+        """
+        req = pecan.request.json
+        if not req.has_key('csr'):
+            pecan.response.status = 400
+            pecan.response.json = {
+                'error': 'A POST to /v1/sign/cert must include a csr.'
+            }
+        else:
+            csr = x509.load_pem_x509_csr(str(req['csr']), default_backend())
+            LOG.info('Received CSR \'%s\', subject = %s', req['csr'], csr.subject)
+            ca_name = CONF['ca_name']
+            signing_role = CONF['signing_role']
+            csr = req['csr']
+            common_name = req.get('common_name', None)
+            ip_sans = req.get('ip_sans', [])
+            alt_names = req.get('alt_names', [])
+            ttl = req.get('ttl', '730h')
+            try:
+                resp = self._vault.sign_csr(ca_name, signing_role, csr,
+                        common_name, ip_sans, alt_names, ttl)
+                pecan.response.json = resp.json()['data']
+                pecan.response.status = 200
+            except requests.HTTPError as e:
+                pecan.response.status = e.response.status_code
+                pecan.response.json = e.response.json()
+
+        return pecan.response
+
+class SignController(object):
+    ca = CAController()
+    cert = CertController()

--- a/vouch/controllers/v1.py
+++ b/vouch/controllers/v1.py
@@ -1,0 +1,4 @@
+from vouch.controllers.sign import SignController
+
+class V1Controller(object):
+    sign = SignController()


### PR DESCRIPTION
 Service can show CA cert, refresh CA, and sign CSR for a CA
mounted in vault. Uses a vault ca module in firkinize

Also added a version endpoint. This will be used by clients (in particular
the hostagent installer) to decide whether or not a controller is capable
of providing individual host certs.

testing:
Need to add unit and integration tests. Used curl to test the
service. Created a simple test program to test the methods in
vouch.