### PR TITLE
Build docker container image for vouch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+
+.SUFFIXES:
+.PHONY: clean push image stage dist unit-test
+
+SRCROOT = $(abspath $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))))
+BUILD_DIR := $(SRCROOT)/build
+VENV := $(SRCROOT)/.venv
+STAGE = $(BUILD_DIR)/container
+$(shell mkdir -p $(STAGE))
+
+VOUCH_CODE = $(shell find $(SRCROOT)/vouch -name '*.py') $(SRCROOT)/setup.py
+VOUCH_DIST = $(STAGE)/vouch-sdist.tgz
+
+FIRKINROOT = $(abspath $(SRCROOT)/../firkinize)
+FIRKIN_CODE = $(shell find $(FIRKINROOT)/firkinize -name '*.py') \
+              $(FIRKINROOT)/setup.py
+FIRKIN_DIST = $(STAGE)/firkinize-sdist.tgz
+
+BUILD_NUMBER ?= 0
+PF9_VERSION ?= 0.0.0
+DOCKER_REPOSITORY ?= 514845858982.dkr.ecr.us-west-1.amazonaws.com/vouch
+BUILD_ID := $(BUILD_NUMBER)
+IMAGE_TAG ?= "$(or $(PF9_VERSION), $(PF9_VERSION), "latest")-$(BUILD_ID)"
+BRANCH_NAME ?= $(or $(TEAMCITY_BUILD_BRANCH), $(TEAMCITY_BUILD_BRANCH), $(shell git symbolic-ref --short HEAD))
+
+dist: $(VOUCH_DIST) $(FIRKIN_DIST)
+
+$(VOUCH_DIST): $(VOUCH_CODE)
+	cd $(SRCROOT) && \
+	rm -f dist/vouch* && \
+	python setup.py sdist && \
+	cp dist/vouch* $@
+
+$(FIRKIN_DIST): $(FIRKIN_CODE)
+	cd $(FIRKINROOT) && \
+	rm -f dist/firkin* && \
+	python setup.py sdist && \
+	cp dist/firkin* $@
+
+stage: dist
+	cp -r $(SRCROOT)/container/* $(STAGE)/
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+$(BUILD_DIR)/container-tag: $(BUILD_DIR)
+	echo -ne "$(IMAGE_TAG)" >$@
+
+unit-test:
+	(test -d $(VENV) || virtualenv $(VENV)) && \
+	$(VENV)/bin/python $(VENV)/bin/pip install -e$(SRCROOT) -e$(FIRKINROOT) nose && \
+	$(VENV)/bin/nosetests -vd .
+
+$(VENV)/bin/y2j:
+	(test -d $(VENV) || virtualenv $(VENV)) && \
+	$(VENV)/bin/python $(VENV)/bin/pip install -e$(FIRKINROOT)
+
+image: stage $(VENV)/bin/y2j
+	docker build -t $(DOCKER_REPOSITORY):$(IMAGE_TAG) \
+		--build-arg BUILD_ID=$(BUILD_ID) \
+		--build-arg VERSION=$(PF9_VERSION) \
+		--build-arg BRANCH=$(BRANCH_NAME) \
+		--build-arg APP_METADATA="$$($(VENV)/bin/y2j $(STAGE)/app_metadata.yaml)" \
+		$(STAGE)
+
+# This assumes that credentials for the aws tool are configured, either in
+# ~/.aws/config or in AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+push: image $(BUILD_DIR)/container-tag
+	docker push $(DOCKER_REPOSITORY):$(IMAGE_TAG) || \
+	(aws ecr get-login --region=us-west-1 |sh && \
+		docker push $(DOCKER_REPOSITORY):$(IMAGE_TAG))
+
+clean:
+	rm -rf $(STAGE)
+	rm -rf $(SRCROOT)/dist
+	rm -rf $(FIRKINROOT)/dist

--- a/bin/vouch
+++ b/bin/vouch
@@ -4,41 +4,35 @@ import logging
 import os
 import paste.deploy
 import paste.httpserver
+import threading
 import vouch.conf
 
 from argparse import ArgumentParser
 
-PECAN_CONF = 'config.py'
-PASTE_INI = 'paste.ini'
-VOUCH_CONF = 'vouch.conf'
-
 logging.basicConfig(level=logging.DEBUG,
-                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+                    format='%(asctime)s - %(name)s - %(threadName)s - '
+                           '%(levelname)s - %(message)s')
 LOG = logging.getLogger(__file__)
 
 def parse_args():
     parser = ArgumentParser(
         description='Run the vouch service',
-        epilog='Example: vouch --config-dir /etc/pf9/vouch')
-    parser.add_argument('--config-dir', default=os.getcwd(),
-        help='Directory where we can find paste.ini, pecan config.py and '
-             'vouch.conf (yaml service configuration)')
+        epilog='Example: vouch --config /etc/vouch/vouch-keystone.conf')
+    parser.add_argument('--config', required=True,
+        help='YAML configuration file.')
     return parser.parse_args()
 
 def run():
     args = parse_args()
-    pecan_conf = os.path.abspath(os.path.join(args.config_dir, PECAN_CONF))
-    paste_ini = os.path.abspath(os.path.join(args.config_dir, PASTE_INI))
-    vouch_conf = os.path.abspath(os.path.join(args.config_dir, VOUCH_CONF))
-    for path in [pecan_conf, paste_ini, vouch_conf]:
-        if not os.path.isfile(path):
-            raise OSError(errno.ENOENT,
-                "Could not locate '%s' in config dir '%s'" %
-                (path, args.config_dir))
-    LOG.info('Starting the vouch signing service.')
+    vouch_conf = os.path.abspath(args.config)
     vouch.conf.set_config(vouch_conf)
+    from vouch.conf import CONF
+    pecan_conf = CONF['pecan_conf']
+    paste_ini = CONF['paste_ini']
+    LOG.info('Starting the vouch signing service.')
     app = paste.deploy.loadapp('config:%s' % paste_ini,
-                               global_conf = {'config' : pecan_conf})
-    paste.httpserver.serve(app, port = 8558)
+                               global_conf={'config' : pecan_conf},
+                               name=CONF['paste_appname'])
+    paste.httpserver.serve(app, host=CONF['listen'])
 
 run()

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,22 @@
+from python:2.7
+
+# install confd
+RUN curl -#fL https://github.com/kelseyhightower/confd/releases/download/v0.15.0/confd-0.15.0-linux-amd64 >/usr/bin/confd \
+ && chmod 755 /usr/bin/confd
+
+# install vouch and supervisor
+COPY vouch-sdist.tgz firkinize-sdist.tgz /tmp/
+RUN pip install --no-cache-dir /tmp/vouch-sdist.tgz /tmp/firkinize-sdist.tgz supervisor \
+ && rm -f /tmp/vouch-sdist.tgz /tmp/firkinize-sdist.tgz
+
+COPY etc/ /etc
+
+ARG APP_METADATA
+LABEL com.platform9.app_metadata=${APP_METADATA}
+ARG VERSION
+LABEL com.platform9.pf9_version=${VERSION}
+ARG BUILD_ID
+LABEL com.platform9.build=${BUILD_ID}
+LABEL com.platform9.version="${VERSION}-${BUILD_ID}"
+ARG BRANCH
+LABEL com.platform9.branch=${BRANCH}

--- a/container/app_metadata.yaml
+++ b/container/app_metadata.yaml
@@ -1,0 +1,26 @@
+---
+- name: vouch-keystone
+  command:
+    - /usr/local/bin/supervisord
+    - --config
+    - /etc/supervisord-keystone.conf
+  endpoints:
+    - name: vouch-public
+      httpPath: /vouch
+      port: 8448
+  logfiles:
+    - path: /var/log/vouch.log
+    - path: /var/log/confd.log
+
+- name: vouch-noauth
+  command:
+    - /usr/local/bin/supervisord
+    - --config
+    - /etc/supervisord-noauth.conf
+  endpoints:
+    - name: vouch-private
+      port: 8558
+  logfiles:
+    - path: /var/log/vouch.log
+    - path: /var/log/confd.log
+

--- a/container/etc/confd/conf.d/paste.toml
+++ b/container/etc/confd/conf.d/paste.toml
@@ -1,0 +1,12 @@
+[template]
+src = 'paste.ini'
+dest = '/etc/vouch/paste.ini'
+owner = 'root'
+mode = '0644'
+keys = [
+    '/fqdn',
+    '/vouch/keystone_user/email',
+    '/vouch/keystone_user/password',
+    '/vouch/keystone_user/project'
+]
+reload_cmd = 'supervisorctl -c /etc/supervisord-keystone.conf restart vouch'

--- a/container/etc/confd/conf.d/vouch-keystone.toml
+++ b/container/etc/confd/conf.d/vouch-keystone.toml
@@ -1,0 +1,14 @@
+[template]
+src = 'vouch-keystone.conf'
+dest = '/etc/vouch/vouch-keystone.conf'
+owner = 'root'
+mode = '0644'
+keys = [
+    '/fqdn',
+    '/vouch/vault/url',
+    '/vouch/vault/token',
+    '/vouch/ca_name',
+    '/vouch/ca_common_name',
+    '/vouch/ca_signing_role'
+]
+reload_cmd = 'supervisorctl -c /etc/supervisord-keystone.conf restart vouch'

--- a/container/etc/confd/conf.d/vouch-noauth.toml
+++ b/container/etc/confd/conf.d/vouch-noauth.toml
@@ -1,0 +1,14 @@
+[template]
+src = 'vouch-noauth.conf'
+dest = '/etc/vouch/vouch-noauth.conf'
+owner = 'root'
+mode = '0644'
+keys = [
+    '/fqdn',
+    '/vouch/vault/url',
+    '/vouch/vault/token',
+    '/vouch/ca_name',
+    '/vouch/ca_common_name',
+    '/vouch/ca_signing_role'
+]
+reload_cmd = 'supervisorctl -c /etc/supervisord-keystone.conf restart vouch'

--- a/container/etc/confd/templates/paste.ini
+++ b/container/etc/confd/templates/paste.ini
@@ -18,11 +18,11 @@ use = egg:Paste#urlmap
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 auth_type = v3password
-auth_url = %(auth_url)s
-memcache_servers = localhost:11211
-username = %(username)s
-password = %(password)s
-project_name = service
+auth_url = https://{{getv "/fqdn"}}/keystone
+#memcache_servers = localhost:11211
+username = {{getv "/vouch/keystone_user/email"}}
+password = {{getv "/vouch/keystone_user/password"}}
+project_name = {{getv "/vouch/keystone_user/project"}}
 delay_auth_decision = False
 user_domain_id = default
 project_domain_id = default

--- a/container/etc/confd/templates/vouch-keystone.conf
+++ b/container/etc/confd/templates/vouch-keystone.conf
@@ -1,0 +1,10 @@
+vault_addr: {{getv "/vouch/vault/url"}}
+vault_token: {{getv "/vouch/vault/token"}}
+vouch_addr: https://{{getv "/fqdn"}}/vouch
+ca_name: {{getv "/vouch/ca_name"}}
+ca_common_name: {{getv "/vouch/ca_common_name"}}
+signing_role: {{getv "/vouch/ca_signing_role"}}
+listen: 0.0.0.0:8448
+paste_ini: paste.ini
+paste_appname: keystone_auth
+pecan_conf: config.py

--- a/container/etc/confd/templates/vouch-noauth.conf
+++ b/container/etc/confd/templates/vouch-noauth.conf
@@ -1,0 +1,10 @@
+vault_addr: {{getv "/vouch/vault/url"}}
+vault_token: {{getv "/vouch/vault/token"}}
+vouch_addr: https://{{getv "/fqdn"}}/vouch
+ca_name: {{getv "/vouch/ca_name"}}
+ca_common_name: {{getv "/vouch/ca_common_name"}}
+signing_role: {{getv "/vouch/ca_signing_role"}}
+listen: 127.0.0.1:8558
+paste_ini: paste.ini
+paste_appname: no_auth
+pecan_conf: config.py

--- a/container/etc/supervisord-keystone.conf
+++ b/container/etc/supervisord-keystone.conf
@@ -1,0 +1,39 @@
+; A good starting point with documentation for this file can be generated
+; from a supervisord installation by running echo_supervisord_conf
+
+[supervisord]
+logfile=/var/log/supervisord.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=debug
+pidfile=/var/run/supervisord.pid
+nodaemon=true
+minfds=1024
+minprocs=200
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[program:vouch]
+command=/usr/local/bin/vouch --config /etc/vouch/vouch-keystone.conf
+autostart=true
+autorestart=true
+startretries=99
+startsecs=1
+redirect_stderr=true
+stdout_logfile=/var/log/vouch.log
+user=root
+
+[program:confd]
+command=/usr/bin/confd -backend consul -node %(ENV_CONFIG_HOST_AND_PORT)s -scheme %(ENV_CONFIG_SCHEME)s -watch -prefix /customers/%(ENV_CUSTOMER_ID)s -auth-token %(ENV_CONSUL_HTTP_TOKEN)s
+redirect_stderr=true
+stdout_logfile=/var/log/confd.log
+autorestart=true
+startretries=99
+startsecs=1

--- a/container/etc/supervisord-noauth.conf
+++ b/container/etc/supervisord-noauth.conf
@@ -1,0 +1,39 @@
+; A good starting point with documentation for this file can be generated
+; from a supervisord installation by running echo_supervisord_conf
+
+[supervisord]
+logfile=/var/log/supervisord.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=debug
+pidfile=/var/run/supervisord.pid
+nodaemon=true
+minfds=1024
+minprocs=200
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[program:vouch]
+command=/usr/local/bin/vouch --config /etc/vouch/vouch-noauth.conf
+autostart=true
+autorestart=true
+startretries=99
+startsecs=1
+redirect_stderr=true
+stdout_logfile=/var/log/vouch.log
+user=root
+
+[program:confd]
+command=/usr/bin/confd -backend consul -node %(ENV_CONFIG_HOST_AND_PORT)s -scheme %(ENV_CONFIG_SCHEME)s -watch -prefix /customers/%(ENV_CUSTOMER_ID)s -auth-token %(ENV_CONSUL_HTTP_TOKEN)s
+redirect_stderr=true
+stdout_logfile=/var/log/confd/confd.log
+autorestart=true
+startretries=99
+startsecs=1

--- a/container/etc/vouch/config.py
+++ b/container/etc/vouch/config.py
@@ -1,0 +1,36 @@
+# Server Specific Configurations
+server = {
+    'port': '8558',
+    'host': '0.0.0.0'
+}
+
+# Pecan Application Configurations
+app = {
+    'root': 'vouch.controllers.root.RootController',
+    'modules': ['vouch'],
+    'debug': False,
+
+    # this 'guess' also strips off the extension from the resource path.
+    'guess_content_type_from_ext': False
+}
+
+logging = {
+    'loggers': {
+        'vouch': {'level': 'DEBUG', 'handlers': ['console']},
+        'keystonemiddleware': {'level': 'DEBUG', 'handlers': ['console']},
+        '__force_dict__': True
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
+        }
+    },
+    'formatters': {
+        'simple': {
+            'format': ('%(asctime)s %(levelname)s [%(name)s]'
+                       '[%(threadName)s] %(message)s')
+        }
+    }
+}

--- a/vouch/conf.py
+++ b/vouch/conf.py
@@ -1,10 +1,27 @@
+
+# pylint: disable=global-statement
+import os
 import yaml
 
 CONF = None
 
-def set_config(filename):
+def set_config(config_file):
     global CONF
     if CONF:
         raise RuntimeError('You can only call set_config once!')
-    with open(filename) as f:
+    with open(config_file) as f:
         CONF = yaml.load(f)
+
+    # paste.ini and config.py can be absolute paths in the config.
+    # If not, check relative to original config
+    for key, default in [('paste_ini', 'paste.ini'),
+                         ('pecan_conf', 'config.py')]:
+        path = CONF.pop(key, default)
+        if os.path.isabs(path):
+            CONF[key] = path
+        else:
+            CONF[key] = os.path.abspath(os.path.join(
+                os.path.dirname(config_file), path))
+        if not os.path.isfile(CONF[key]):
+            raise RuntimeError('Could not find config file %s at %s'
+                               % (key, CONF[key]))


### PR DESCRIPTION
Build a container for vouch including supervisor and confd configurations.
+ The image can be run with or without keystone authentication.
+ the app_metadata provides command lines for each, exposing only the
  keystone auth version in the web ingress.

testing:
+ mocked up consul setup so I could render the configs.
+ ran both versions of the service and tested it with a few requests.

TODO: write an init-region to create vault credentials and a keystone user.