### PR TITLE
pin the vault container version to a "release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,12 @@ $(FIRKIN_DIST): $(FIRKIN_CODE)
 	python setup.py sdist && \
 	cp dist/firkin* $@
 
+# Vault version pinned to 208daedff8dcba4d922c8b385666c637c7748b75,
+# in order to do proper releasing around backwards incompatible changes.
 $(VAULT_DIST): $(VAULT_CODE)
 	cd $(VAULTROOT) && \
 	rm -f dist/vault* && \
+	git checkout 208daedff8dcba4d922c8b385666c637c7748b75 && \
 	python setup.py sdist && \
 	cp dist/vault* $@
 


### PR DESCRIPTION
I have a set of changes to apply to vault/vouch that need to be released at the same time, but there is currently no way to version pin which release of vault is installed to the vouch container. So, no way to merge one without the other, test, or otherwise avoid #YOLOpushing them both and watching what blows up.

So, here's one. It's gross as heck, don't tell anyone, it'll be gone soon.