### PR TITLE
create host signing token using a vault token role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,11 @@ $(FIRKIN_DIST): $(FIRKIN_CODE)
 	python setup.py sdist && \
 	cp dist/firkin* $@
 
-# Vault version pinned to 4f6d7e3f4d65b418ea76df99be4e504f59b80bee,
-# in order to do proper releasing around backwards incompatible changes.
+# Vault version pinned here in lieu of using pip.
 $(VAULT_DIST): $(VAULT_CODE)
 	cd $(VAULTROOT) && \
 	rm -f dist/vault* && \
-	git checkout 4f6d7e3f4d65b418ea76df99be4e504f59b80bee && \
+	git checkout 7fc197d3f9240cdd0920ff93e6d3cb36199bae03 && \
 	python setup.py sdist && \
 	cp dist/vault* $@
 

--- a/bin/init-region
+++ b/bin/init-region
@@ -145,10 +145,10 @@ def create_host_signing_role(vault, consul, customer_id):
     return rolename
 
 
-def create_host_signing_token(vault, consul, customer_id, rolename):
+def create_host_signing_token(vault, consul, customer_id, rolename, token_rolename='vouch-hosts'):
     policy_name = 'hosts-%s' % customer_id
     vault.create_signing_token_policy(rolename, policy_name)
-    token_info = vault.create_token(policy_name)
+    token_info = vault.create_token(policy_name, token_role=token_rolename)
     consul.kv_put('customers/%s/vouch/vault/url' % customer_id, vault.addr)
     consul.kv_put('customers/%s/vouch/vault/host_signing_token' % customer_id,
                   token_info.json()['auth']['client_token'])


### PR DESCRIPTION
Upgrades to a version of vaultlib that supports creating tokens with a particular token role, and uses the role `vouch-hosts` to create these tokens going forward.