### PR TITLE
reduce queries to confd backend

### DIFF
--- a/container/etc/confd/conf.d/paste.toml
+++ b/container/etc/confd/conf.d/paste.toml
@@ -5,8 +5,6 @@ owner = 'root'
 mode = '0644'
 keys = [
     '/fqdn',
-    '/vouch/keystone_user/email',
-    '/vouch/keystone_user/password',
-    '/vouch/keystone_user/project'
+    '/vouch',
 ]
 reload_cmd = 'supervisorctl -c /etc/supervisord-keystone.conf restart vouch'

--- a/container/etc/confd/conf.d/vouch-keystone.toml
+++ b/container/etc/confd/conf.d/vouch-keystone.toml
@@ -5,10 +5,6 @@ owner = 'root'
 mode = '0644'
 keys = [
     '/fqdn',
-    '/vouch/vault/url',
-    '/vouch/vault/host_signing_token',
-    '/vouch/ca_name',
-    '/vouch/ca_common_name',
-    '/vouch/ca_signing_role'
+    '/vouch',
 ]
 reload_cmd = 'supervisorctl -c /etc/supervisord-keystone.conf restart vouch'

--- a/container/etc/confd/conf.d/vouch-noauth.toml
+++ b/container/etc/confd/conf.d/vouch-noauth.toml
@@ -5,10 +5,6 @@ owner = 'root'
 mode = '0644'
 keys = [
     '/fqdn',
-    '/vouch/vault/url',
-    '/vouch/vault/host_signing_token',
-    '/vouch/ca_name',
-    '/vouch/ca_common_name',
-    '/vouch/ca_signing_role'
+    '/vouch',
 ]
 reload_cmd = 'supervisorctl -c /etc/supervisord-keystone.conf restart vouch'


### PR DESCRIPTION
tldr, confd backend queries are recursive but each key causes a seperate query, so querying the root of a needed tree causes fewer queries and makes the same data available. more info - https://github.com/platform9/pf9-enclave/pull/7