### PR TITLE
use alpine as base docker image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -5,7 +5,7 @@ from python:2.7-alpine
 RUN apk add libffi-dev mariadb-connector-c-dev build-base
 
 # install confd
-RUN wget -o /usr/bin/confd \
+RUN wget -O /usr/bin/confd \
     https://github.com/kelseyhightower/confd/releases/download/v0.15.0/confd-0.15.0-linux-amd64 \
     && chmod 755 /usr/bin/confd
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,8 +1,13 @@
-from python:2.7
+from python:2.7-alpine
+
+# libffi-dev and build-base required by python's cryptography
+# mariadb-connector-c-dev/mysql_config required for python's mysqlclient
+RUN apk add libffi-dev mariadb-connector-c-dev build-base
 
 # install confd
-RUN curl -#fL https://github.com/kelseyhightower/confd/releases/download/v0.15.0/confd-0.15.0-linux-amd64 >/usr/bin/confd \
- && chmod 755 /usr/bin/confd
+RUN wget -o /usr/bin/confd \
+    https://github.com/kelseyhightower/confd/releases/download/v0.15.0/confd-0.15.0-linux-amd64 \
+    && chmod 755 /usr/bin/confd
 
 # install vouch and supervisor
 COPY vouch-sdist.tgz firkinize-sdist.tgz vault-sdist.tgz /tmp/


### PR DESCRIPTION
Using a smaller base image reduces the final image size from 1GB to 378M. Almost half of that comes from gcc/g++ but those are required to build the python requirements.

curl changed to wget because curl is not in the alpine image.