### PR TITLE
use internal path for keystone api

### DIFF
--- a/container/app_metadata.yaml
+++ b/container/app_metadata.yaml
@@ -9,6 +9,9 @@
       httpPath: /vouch
       port: 8448
       rewritePath: "/"
+  egresses:
+    - endpoint: keystone-internal
+      localPort: 8080
   logfiles:
     - path: /var/log/vouch.log
     - path: /var/log/confd.log

--- a/container/etc/confd/templates/paste.ini
+++ b/container/etc/confd/templates/paste.ini
@@ -18,7 +18,7 @@ use = egg:Paste#urlmap
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 auth_type = v3password
-auth_url = https://{{getv "/fqdn"}}/keystone/v3
+auth_url = http://localhost:8080/keystone/v3
 #memcache_servers = localhost:11211
 username = {{getv "/vouch/keystone_user/email"}}
 password = {{getv "/vouch/keystone_user/password"}}


### PR DESCRIPTION
Connect to the DDU keystone using an internal endpoint instead of the public FQDN.