### PR TITLE
AIR-129 Dockerfile and Makefile changes for image size reduction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,6 @@ $(shell mkdir -p $(STAGE))
 VOUCH_CODE = $(shell find $(SRCROOT)/vouch -name '*.py') $(SRCROOT)/setup.py
 VOUCH_DIST = $(STAGE)/vouch-sdist.tgz
 
-FIRKINROOT = $(abspath $(SRCROOT)/../firkinize)
-FIRKIN_CODE = $(shell find $(FIRKINROOT)/firkinize -name '*.py') \
-              $(FIRKINROOT)/setup.py
-FIRKIN_DIST = $(STAGE)/firkinize-sdist.tgz
-
 VAULTROOT = $(abspath $(SRCROOT)/../vault)
 VAULT_CODE = $(shell find $(VAULTROOT)/vault -name '*.py') $(VAULTROOT)/setup.py
 VAULT_DIST = $(STAGE)/vault-sdist.tgz
@@ -27,19 +22,13 @@ BUILD_ID := $(BUILD_NUMBER)
 IMAGE_TAG ?= "$(or $(PF9_VERSION), $(PF9_VERSION), "latest")-$(BUILD_ID)"
 BRANCH_NAME ?= $(or $(TEAMCITY_BUILD_BRANCH), $(TEAMCITY_BUILD_BRANCH), $(shell git symbolic-ref --short HEAD))
 
-dist: $(VOUCH_DIST) $(FIRKIN_DIST) $(VAULT_DIST)
+dist: $(VOUCH_DIST) $(VAULT_DIST)
 
 $(VOUCH_DIST): $(VOUCH_CODE)
 	cd $(SRCROOT) && \
 	rm -f dist/vouch* && \
 	python setup.py sdist && \
 	cp dist/vouch* $@
-
-$(FIRKIN_DIST): $(FIRKIN_CODE)
-	cd $(FIRKINROOT) && \
-	rm -f dist/firkin* && \
-	python setup.py sdist && \
-	cp dist/firkin* $@
 
 # Vault version pinned here in lieu of using pip.
 $(VAULT_DIST): $(VAULT_CODE)
@@ -63,19 +52,16 @@ $(BUILD_DIR)/container-tag: $(BUILD_DIR)
 	echo -ne "$(IMAGE_TAG)" >$@
 
 unit-test: $(VENV)
-	$(VENV)/bin/python $(VENV)/bin/pip install -e$(SRCROOT) -e$(FIRKINROOT) \
+	$(VENV)/bin/python $(VENV)/bin/pip install -e$(SRCROOT) \
 	-e$(VAULTROOT) nose && \
 	$(VENV)/bin/nosetests -vd .
 
-$(VENV)/bin/y2j: $(VENV)
-	$(VENV)/bin/python $(VENV)/bin/pip install -e$(FIRKINROOT)
-
-image: stage $(VENV)/bin/y2j
+image: stage
 	docker build -t $(DOCKER_REPOSITORY):$(IMAGE_TAG) \
 		--build-arg BUILD_ID=$(BUILD_ID) \
 		--build-arg VERSION=$(PF9_VERSION) \
 		--build-arg BRANCH=$(BRANCH_NAME) \
-		--build-arg APP_METADATA="$$($(VENV)/bin/y2j $(STAGE)/app_metadata.yaml)" \
+		--build-arg APP_METADATA="$$(python $(SRCROOT)/y2j $(STAGE)/app_metadata.yaml)" \
 		$(STAGE)
 
 # This assumes that credentials for the aws tool are configured, either in
@@ -89,5 +75,4 @@ clean:
 	rm -rf $(VENV)
 	rm -rf $(STAGE)
 	rm -rf $(SRCROOT)/dist
-	rm -rf $(FIRKINROOT)/dist
 	rm -rf $(VAULTROOT)/dist

--- a/bin/init-region
+++ b/bin/init-region
@@ -84,8 +84,8 @@ def random_string(length=16):
     generate a string made of random numbers and letters that always starts
     with a letter.
     """
-    secret_chars = string.letters + string.digits
-    return ''.join([random.SystemRandom().choice(string.letters)] +
+    secret_chars = string.ascii_letters + string.digits
+    return ''.join([random.SystemRandom().choice(string.ascii_letters)] +
                    [random.SystemRandom().choice(secret_chars)
                     for _ in range(length - 1)])
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,14 +1,10 @@
-from python:2.7
+from artifactory.platform9.horse/docker-local/pf9-py36-baseimg:5.4.0-stable
 
-# install confd
-RUN curl -#fL https://github.com/kelseyhightower/confd/releases/download/v0.15.0/confd-0.15.0-linux-amd64 >/usr/bin/confd \
- && chmod 755 /usr/bin/confd
-
-# install vouch and supervisor
-COPY vouch-sdist.tgz firkinize-sdist.tgz vault-sdist.tgz /tmp/
-RUN pip install --no-cache-dir /tmp/vouch-sdist.tgz /tmp/firkinize-sdist.tgz \
- /tmp/vault-sdist.tgz supervisor \
- && rm -f /tmp/vouch-sdist.tgz /tmp/firkinize-sdist.tgz /tmp/vault-sdist.tgz \
+# install vouch
+COPY vouch-sdist.tgz vault-sdist.tgz /tmp/
+RUN pip install --no-cache-dir /tmp/vouch-sdist.tgz \
+ /tmp/vault-sdist.tgz \
+ && rm -f /tmp/vouch-sdist.tgz /tmp/vault-sdist.tgz \
  && ln -s /usr/local/bin/init-region /root/init-region
 
 COPY etc/ /etc

--- a/vouch/controllers/sign.py
+++ b/vouch/controllers/sign.py
@@ -84,13 +84,13 @@ class CertController(RestController):
         ip_sans, and a ttl (e.g. 780h)
         """
         req = pecan.request.json
-        if not req.has_key('csr'):
+        if not 'csr' in req:
             pecan.response.status = 400
             pecan.response.json = {
                 'error': 'A POST to /v1/sign/cert must include a csr.'
             }
         else:
-            csr = x509.load_pem_x509_csr(str(req['csr']), default_backend())
+            csr = x509.load_pem_x509_csr(str(req['csr']).encode('utf-8'), default_backend())
             LOG.info('Received CSR \'%s\', subject = %s', req['csr'], csr.subject)
             ca_name = CONF['ca_name']
             signing_role = CONF['signing_role']

--- a/vouch/tests/test_sign.py
+++ b/vouch/tests/test_sign.py
@@ -4,4 +4,4 @@ import vouch
 
 class TestSign(TestCase):
     def test_is_string(self):
-        self.assertTrue(isinstance('string', basestring))
+        self.assertTrue(isinstance('string', str))

--- a/y2j
+++ b/y2j
@@ -1,0 +1,9 @@
+import yaml
+import json
+import sys
+
+fname = sys.argv[1]
+with open(fname, 'r') as f:
+    data = yaml.load(f)
+    out = json.dumps(data, separators=(',', ':'))
+    print(out)


### PR DESCRIPTION
## ISSUE(S):
https://platform9.atlassian.net/browse/AIR-129
AIR-129 Dockerfile and Makefile changes for image size reduction in vouch

## SUMMARY
The purpose is to reduce the overall size of DDU images.
Currently vouch container image is created using base image - python:2.7
A new base image which is built based on python-slim-buster can be used to reduce overall size of the image on the DDU
This new image is available on ECR.
This image has been used in the vouch container as a base image. Fixed pre-existing unit test case failure.
Also, changes related to py2-py3 porting fixed.
## ISSUE TYPE
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## IMPACTED FEATURES/COMPONENTS:
vouch container

## TESTING DONE
#### Automated
kplane-smoke-test
https://teamcity.platform9.horse/viewLog.html?buildId=1645678&tab=buildResultsDiv&buildTypeId=Pf9project_DeccoBuilds_KplaneSmokeTest

#### Reviewers
/cc @pshanbhag @yogeshj83 

