### PR TITLE
multi CA changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,9 @@ $(VOUCH_DIST): $(VOUCH_CODE)
 	python setup.py sdist && \
 	cp dist/vouch* $@
 
-# Vault version pinned here in lieu of using pip.
 $(VAULT_DIST): $(VAULT_CODE)
 	cd $(VAULTROOT) && \
 	rm -f dist/vault* && \
-	git checkout 7fc197d3f9240cdd0920ff93e6d3cb36199bae03 && \
 	python setup.py sdist && \
 	cp dist/vault* $@
 

--- a/bin/init-region
+++ b/bin/init-region
@@ -147,7 +147,7 @@ def create_host_signing_role(vault, consul, customer_id):
 
 def create_host_signing_token(vault, consul, customer_id, rolename, token_rolename='vouch-hosts'):
     policy_name = 'hosts-%s' % customer_id
-    vault.create_signing_token_policy(rolename, policy_name)
+    vault.create_vouch_token_policy(rolename, policy_name)
     token_info = vault.create_token(policy_name, token_role=token_rolename)
     consul.kv_put('customers/%s/vouch/vault/url' % customer_id, vault.addr)
     consul.kv_put('customers/%s/vouch/vault/host_signing_token' % customer_id,


### PR DESCRIPTION
Uses a different function in vaultlib during init-region to get a token with expanded permissions for the runtime vouch processes.