### PR TITLE
Move vouch build to use py39

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-from artifactory.platform9.horse/docker-local/pf9-py36-baseimg:5.4.0-stable
+from artifactory.platform9.horse/docker-local/pf9-py39-baseimg:stable
 
 # install vouch
 COPY vouch-sdist.tgz vault-sdist.tgz /tmp/

--- a/run-staging-in-container.sh
+++ b/run-staging-in-container.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+set -exu
+CONTAINER_BUILD_IMAGE=artifactory.platform9.horse/docker-local/py39-build-image:latest
+
+THIS_FILE=$(realpath $0)
+THIS_DIR=$(dirname ${THIS_FILE})
+BUILD_UID=$(id -u)
+BUILD_GID=$(id -g)
+docker run -i --rm -a stdout -a stderr \
+   -v ${THIS_DIR}:/buildroot/vouch \
+   -v ${THIS_DIR}/../vault:/buildroot/vault \
+   -e PF9_VERSION=${PF9_VERSION} \
+   -e BUILD_NUMBER=${BUILD_NUMBER} \
+   -u ${BUILD_UID}:${BUILD_GID} \
+   ${CONTAINER_BUILD_IMAGE} \
+   /buildroot/vouch/stage-with-container-build.sh

--- a/stage-with-container-build.sh
+++ b/stage-with-container-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -xue
+
+cd /buildroot/vouch && make --max-load=$(nproc) stage-with-py-container


### PR DESCRIPTION
This change covers 2 parts:
1. Move the build of vouch py tgz into a py39 container.
2. Use py39 base container image for the vouch container

Issues: CORE-1233