### PR TITLE
CORE946: Return CA list

### DIFF
--- a/vouch/conf.py
+++ b/vouch/conf.py
@@ -25,3 +25,14 @@ def set_config(config_file):
         if not os.path.isfile(CONF[key]):
             raise RuntimeError('Could not find config file %s at %s'
                                % (key, CONF[key]))
+    try:
+        customer_id = os.environ['CUSTOMER_ID']
+        region_id = os.environ['REGION_ID']
+        consul_url = os.environ['CONFIG_URL']
+        consul_token = os.environ['CONSUL_HTTP_TOKEN']
+        CONF['customer_id']=customer_id
+        CONF['region_id']=region_id
+        CONF['consul_url']=consul_url
+        CONF['consul_token']=consul_token
+    except KeyError as e:
+        raise RuntimeError('Failed to set consul config, missing environment:', e)

--- a/vouch/controllers/CA.py
+++ b/vouch/controllers/CA.py
@@ -1,0 +1,56 @@
+# pylint: disable=too-few-public-methods
+
+import logging
+import pecan
+import re
+
+from pecan import expose
+from pecan.rest import RestController
+
+from vouch.conf import CONF
+from firkinize.configstore.consul import Consul
+
+LOG = logging.getLogger(__name__)
+
+def _json_error_response(response, code, exc):
+    """
+    json response from an exception object
+    """
+    response.status = code
+    response.content_type = 'application/json'
+    response.charset = 'utf-8'
+    try:
+        response.json = {'message': '%s: %s' % (exc.__class__.__name__, exc)}
+    except Exception:
+        response.json = {'message': 'Request Failed'}
+    return response
+
+class ListCAController(RestController):
+    def __init__(self):
+        self._consul = Consul(
+            CONF['consul_url'],
+            CONF['consul_token'],
+        )
+        self._prefix = 'customers/%s/regions/%s' % (CONF['customer_id'], CONF['region_id'])
+
+    @expose('json')
+    def get(self):
+        """
+        GET /v1/cas
+        Get the list of all active root CAs
+        """
+        LOG.info('Fetching list of current ca certificates')
+        try:
+            certs =  self._consul.kv_get_prefix(self._prefix+ '/certs')
+            active_ca = []
+            for k in certs:
+                pattern = '^'+ self._prefix +'/certs/v\d+/ca/cert$'
+                if re.search(pattern,k):
+                    active_ca.append(certs[k])
+            pecan.response.status = 200
+            pecan.response.json = active_ca
+        except Exception as e:
+            LOG.error('Could not fetch CA certs from consul', e)
+            return _json_error_response(pecan.response, 500, e)
+            pecan.response.status = 500
+        return pecan.response

--- a/vouch/controllers/v1.py
+++ b/vouch/controllers/v1.py
@@ -1,4 +1,6 @@
 from vouch.controllers.sign import SignController
+from vouch.controllers.CA import ListCAController
 
 class V1Controller(object):
     sign = SignController()
+    cas = ListCAController()


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [CORE-XXXX](link.to/CORE-XXXX): Subject of CORE-XXXX -->
https://platform9.atlassian.net/browse/CORE-946
## SUMMARY
<!--- Describe the change below -->
Add new endpoint `http://localhost:8558/v1/listca`
It returns list of all CAs present in consul (`<prefix>/certs/<version_no>/ca/cert`)
Note: It doesn’t check for CA's expiry date
<!--- include "Fixes #CORE-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTING DONE
#### Manual
Manually added a new CA in consul.
Checked if all configured CAs are returned.
#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @pshanbhag @brandune 
<!--- The do-not-merge/hold label gives you power to control when the PR should be automatically merged -->
<!--- Apply later in a comment, or apply here by uncommenting the line below -->
<!--- /hold -->
<!--- This label can be removed via comment -->
<!--- Remove by commenting /hold cancel -->
