### PR TITLE
Bring back the rest controller

### DIFF
--- a/vouch/controllers/root.py
+++ b/vouch/controllers/root.py
@@ -1,14 +1,14 @@
 from vouch.controllers.v1 import V1Controller
 from vouch.controllers.metrics_controller import MetricsController
 from pecan import expose
-# from pecan.rest import RestController
+from pecan.rest import RestController
 
 from vouch.conf import CONF
 
-class RootController():
+class RootController(RestController):
     v1 = V1Controller()
     metrics = MetricsController()
-    
+
     @expose('json')
     def get(self):
         """


### PR DESCRIPTION
Not sure why this was dropped but it is leading to failure in the hostagent test
for vouch reachability. Make it available again for now.