### PR TITLE
[backport 5.6] AIR-703 Moved to pf9-py39-baseimg-alpine to resolve OS related vulnerabilites for vouch

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,8 @@
-from artifactory.platform9.horse/docker-local/pf9-py39-baseimg:stable
+from artifactory.platform9.horse/docker-local/pf9-py39-baseimg-alpine:stable
+
+RUN apk update && apk add bash \
+    && apk add curl \
+    && rm -vrf /var/cache/apk/*
 
 # install vouch
 COPY vouch-sdist.tgz vault-sdist.tgz /tmp/


### PR DESCRIPTION
## ISSUE(S):
[AIR-703](https://platform9.atlassian.net/browse/AIR-703)

## SUMMARY
Trivy scan on the image `514845858982.dkr.ecr.us-west-1.amazonaws.com/vouch:5.7.0-257` gives total: 73 vulnerabilities  (HIGH: 48, CRITICAL: 25) due to debian OS, and 7 python package vulnerabilities ( HIGH: 4, CRITICAL: 3). Moved to pf9-py39-alpine-baseimg ( alpine:3.16 OS) which has no vulnerabilities. Upgraded pyYaml python package to 5.4 (firkinize), didn't upgrade urllib3 because of dependency conflicts.

Image `514845858982.dkr.ecr.us-west-1.amazonaws.com/vouch:5.6.4-293` pushed to ECR via [this](https://teamcity.platform9.horse/viewLog.html?buildId=2489764&buildTypeId=Pf9project_ContainerBuilds_VouchContainer&tab=buildLog&_focus=1363#_state=871) TC build
Running a trivy scan on the image shows only two vulnerabilities (both of HIGH severity) due to `urllib3`(couldn't upgrade due to dependency conflicts) and `setuptools` (version 46.4.0 is pinned in firkinize repo for py2 support) python packages
```
trivy image  -s CRITICAL,HIGH --exit-code 22 514845858982.dkr.ecr.us-west-1.amazonaws.com/vouch:5.6.4-293
2023-01-04T06:13:06.652Z	INFO	Need to update DB
2023-01-04T06:13:06.652Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-01-04T06:13:06.652Z	INFO	Downloading DB...
35.92 MiB / 35.92 MiB [-----------------------------------------------------------------------------------------------------------] 100.00% 14.04 MiB p/s 2.8s
2023-01-04T06:13:10.176Z	INFO	Vulnerability scanning is enabled
2023-01-04T06:13:10.176Z	INFO	Secret scanning is enabled
2023-01-04T06:13:10.176Z	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2023-01-04T06:13:10.176Z	INFO	Please see also https://aquasecurity.github.io/trivy/0.30.1/docs/secret/scanning/#recommendation for faster secret detection
2023-01-04T06:13:10.475Z	INFO	Detected OS: alpine
2023-01-04T06:13:10.475Z	INFO	Detecting Alpine vulnerabilities...
2023-01-04T06:13:10.481Z	INFO	Number of language-specific files: 1
2023-01-04T06:13:10.481Z	INFO	Detecting python-pkg vulnerabilities...
2023-01-04T06:13:10.491Z	INFO	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Python (python-pkg)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌───────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│        Library        │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├───────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ setuptools (METADATA) │ CVE-2022-40897 │ HIGH     │ 46.4.0            │ 65.5.1        │ CVE-2022-40897 affecting package python-setuptools 40.2.0-6 │
│                       │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-40897                  │
├───────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ urllib3 (METADATA)    │ CVE-2021-33503 │ HIGH     │ 1.24.2            │ 1.26.5        │ python-urllib3: ReDoS in the parsing of authority part of   │
│                       │                │          │                   │               │ URL                                                         │
│                       │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2021-33503                  │
└───────────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```

## TESTING DONE:

010-pmk-smoke-test : https://teamcity.platform9.horse/viewLog.html?buildId=2491145&tab=buildResultsDiv&buildTypeId=Pf9project_IntegrationPipelineOnKubeDU_010pmkSmokeTests_2

ddu-chart build used for this: https://teamcity.platform9.horse/viewLog.html?buildId=2489917&tab=buildResultsDiv&buildTypeId=Pf9project_Releases_000dduChart56

[AIR-703]: https://platform9.atlassian.net/browse/AIR-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIR-703]: https://platform9.atlassian.net/browse/AIR-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ