### PR TITLE
[5.6] Add readiness checks for vouch (#24)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install --no-cache-dir /tmp/vouch-sdist.tgz \
  && ln -s /usr/local/bin/init-region /root/init-region
 
 COPY etc/ /etc
+COPY scripts/ /
 
 ARG APP_METADATA
 LABEL com.platform9.app_metadata=${APP_METADATA}

--- a/container/scripts/readiness_checks.sh
+++ b/container/scripts/readiness_checks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+VAULT_URL=$(curl --header "X-Consul-Token: $CONSUL_HTTP_TOKEN" $CONSUL_HTTP_ADDR/v1/kv/customers/$CUSTOMER_ID/vouch/vault/url?raw 2>/dev/null)
+VAULT_TOKEN=$(grep vault_token /etc/vouch/vouch-keystone.conf | awk '{ print $2 }')
+
+TOKEN_HEALTH_STATUS=$(curl -o /dev/null -s -w "%{http_code}\n" --header "X-Vault-Token: $VAULT_TOKEN" $VAULT_URL/v1/auth/token/lookup-self)
+
+if [ $TOKEN_HEALTH_STATUS != "200" ]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
* Backport of https://github.com/platform9/vouch/pull/24
* 5.6 deployments are failing because vouch pods are failing with error
```
  Warning  Unhealthy  4m41s (x45651 over 2d11h)  kubelet  (combined from similar events): Readiness probe errored: rpc error: code = Unknown desc = failed to exec in container: failed to start exec   
 "751ebac10bf479e9186f09c595de04a59a8b6e6751a38618582db634b7dd96b5": OCI runtime exec failed: exec failed:    
 unable to start container process: exec: "/readiness_checks.sh": stat /readiness_checks.sh: no such file or directory: unknown
```
This is because corresponding kubedu change (https://github.com/platform9/kubedu/pull/156) has been merged in 5.6, but vouch change is not backported in 5.6