### PR TITLE
PMK-5979 Add error log if vault signing csr failed.

### DIFF
--- a/vouch/controllers/sign.py
+++ b/vouch/controllers/sign.py
@@ -107,6 +107,11 @@ class CertController(RestController):
                 pecan.response.json = resp.json()['data']
                 pecan.response.status = 200
             except requests.HTTPError as e:
+                LOG.error(
+                    'CSR Signing failed. Error code \'%s\', with response \'%s\'',
+                    e.response.status_code,
+                    e.response.json()
+                )
                 pecan.response.status = e.response.status_code
                 pecan.response.json = e.response.json()
 


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [CORE-XXXX](link.to/CORE-XXXX): Subject of CORE-XXXX -->
[PMK-5979](https://platform9.atlassian.net/browse/PMK-5979)

## SUMMARY
<!--- Describe the change below -->
Adding log statement while signing cert.

<!--- include "Fixes #CORE-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
vouch

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->

## DEPENDS ON:
<!--- Links to related PRs if any -->
<!--- delete section if not relevant -->

## TESTING DONE
#### Automated

#### Manual
# Steps to test 5797
1. Create a PMK cluster
2. ssh into any one node and create a trial csr without any common name or other details.
```
# openssl req -newkey rsa:2048 -keyout PRIVATEKEY.key -out MYCSR.csr
Generating a RSA private key
.........................................+++++
...........................................+++++
writing new private key to 'PRIVATEKEY.key'
Enter PEM pass phrase:
Verifying - Enter PEM pass phrase:
-----
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [AU]:
State or Province Name (full name) [Some-State]:
Locality Name (eg, city) []:
Organization Name (eg, company) [Internet Widgits Pty Ltd]:
Organizational Unit Name (eg, section) []:
Common Name (e.g. server FQDN or YOUR name) []:
Email Address []:

Please enter the following 'extra' attributes
to be sent with your certificate request
A challenge password []:
An optional company name []:
```

3. Use below python script to trigger a POST request to vouch on any node attached to cluster to sign the invalid CSR to verify the logging. Note the below script is to be run on python3 shell.
```
# python3
Python 3.8.5 (default, Jul 28 2020, 12:59:40) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> with open("MYCSR.csr") as file:
...     csr=file.read()
...
>>> a=requests.post('http://localhost:8558/v1/sign/cert',json={"x-auth-token":"gAAAAABk8Blr6DH2A-KJQCidE_lzTkE_hD6JlUBgefQFFv_Aj0F1LAzop5sagQFMCliNz_9UgMoes15Ma7cycbh7FYazyNq1wA-22IziZHk8TDn0zk8Ll0zRC6XkPRQS3Bmm7HXfmyC5rWceKAsJBoK78TzEse4XPJtBfNb5BzrqM9AAaTbpEhVE853d_U3BvcbGOXt5L8jU","csr":csr})
>>> a.content
b'{"errors":["the common_name field is required, or must be provided in a CSR with \\"use_csr_common_name\\" set to true, unless \\"require_cn\\" is set to false"]}'
>>> a.status_code
400
```

4. The Error log can be seen in the vouch-noauth pod as well
```
2023-08-31 05:57:03,602 ERROR [vouch.controllers.sign][worker 0] CSR Signing failed. Error code '400', with response '{'errors': ['the common_name field is required, or must be provided in a CSR with "use_csr_common_name" set to true, unless "require_cn" is set to false']}'
2023-08-31 05:57:03,602 - vouch.controllers.sign - worker 0 - ERROR - CSR Signing failed. Error code '400', with response '{'errors': ['the common_name field is required, or must be provided in a CSR with "use_csr_common_name" set to true, unless "require_cn" is set to false']}'
```

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->

<!--- The do-not-merge/hold label gives you power to control when the PR should be automatically merged -->
<!--- Apply later in a comment, or apply here by uncommenting the line below -->
<!--- /hold -->
<!--- This label can be removed via comment -->
<!--- Remove by commenting /hold cancel -->
