### PR TITLE
[5.9] vouch : Updating pip, setuptools, cryptography and sundry modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(BUILD_DIR):
 
 $(VENV):
 	(test -d $(VENV) || virtualenv $(VENV)) && \
-	$(VENV)/bin/python $(VENV)/bin/pip install pip==19.0.3 setuptools==42.0.2
+	$(VENV)/bin/python $(VENV)/bin/pip install pip==23.3.1 setuptools==68.2.2
 
 $(BUILD_DIR)/container-tag: $(BUILD_DIR)
 	echo -ne "$(IMAGE_TAG)" >$@

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ setup(
     author='',
     author_email='',
     install_requires=[
-        'cryptography==2.6.1',
-        'keystonemiddleware==6.0.0',
-        'Paste==3.0.8',
-        'PasteDeploy==2.0.1',
-        'prometheus-client==0.7.1',
-        'pecan==1.3.2',
-        'python-memcached==1.59'
+        'cryptography==41.0.4', # https://pypi.org/project/cryptography/
+        'keystonemiddleware==10.4.1', # https://pypi.org/project/keystonemiddleware/
+        'Paste==3.7.1',
+        'PasteDeploy==3.0.1',
+        'prometheus-client==0.17.1', # https://pypi.org/project/prometheus-client/
+        'pecan==1.5.1', # https://github.com/pecan/pecan/tags
+        'python-memcached==1.59' #https://github.com/linsomniac/python-memcached/releases
     ],
     scripts=['bin/vouch', 'bin/init-region'],
     test_suite='nose.collector',


### PR DESCRIPTION
With the new Python 3.9 alpine 3.18 based image pf9-py39-base-image, vouch container cannot be built since the older pip tries to build cryptography module from source and fails. 

Fixes https://platform9.atlassian.net/browse/PMK-6129