### PR TITLE
if the region level vouch config is not present, fabricate it as best…

### DIFF
--- a/bin/common.py
+++ b/bin/common.py
@@ -17,6 +17,29 @@ logging.basicConfig(level=logging.DEBUG)
 LOG = logging.getLogger(__name__)
 
 """
+note from tdell:
+
+Originally there lived a single "vouch" section at the customer level. It was written at a time
+when we supported only single regions, and when multi-region support was finally added, it would be
+clobbered by subsequent region deployments. This meant hosts could only be onboarded to the
+region most recently deployed.
+
+Now there are "service/vouch" sections at the region level. Though we have a legacy vouch
+section at the customer level, please mostly ignore it.
+
+The ca_signing_role was originally hosts-{customer_name}. But in it we find a policy for a single
+region, so we had a choice to either add additional regions to this policy, or create policies
+for each region. The latter decision was taken.
+
+Now each region has its own ca_signing_role as hosts-{region_name}.
+
+Some old deployments are extant. There is now a fabricate_missing_data() function that creates
+a region-level vouch configuration during upgrade. In doing so it might create new vault tokens.
+
+I did not enjoy untangling this.
+"""
+
+"""
 init-region utility for setting up the vouch environment. Expects the following
 as a starting point:
 
@@ -125,9 +148,94 @@ def add_keystone_user(consul, customer_uuid):
         LOG.info('Added vouch user')
 
 
+def fabricate_missing_data(consul, customer_uuid, region_uuid):
+
+    LOG.info(f'fabricating regional vouch config for {region_uuid}')
+
+    cert_version = consul.kv_get(f'customers/{customer_uuid}/regions/{region_uuid}/certs/current_version')
+
+    # Obtain the shared_ca_name, which is quite possibly clobbered. We only need the very first component
+    # of this, the secrets engine, which might look like "pki" or "pki_prod" or "pki_pmkft", etc.
+
+    # looks like "pki/versioned/9d524532-61f0-41ac-a85a-64a3f5ac0656/v0"
+
+    shared_ca_name = consul.kv_get(f'customers/{customer_uuid}/vouch/ca_name')
+    secrets_engine = shared_ca_name.split("/")[0]
+
+    ca_name = f'{secrets_engine}/versioned/{region_uuid}/{cert_version}'
+
+    # Our ca_common_name is always the DU shortname
+
+    du_fqdn = consul.kv_get(f'customers/{customer_uuid}/regions/{region_uuid}/fqdn')
+    ca_common_name = du_fqdn.split(".")[0]
+
+    # Our ca_signing_role is per-region, but used to be per-customer
+
+    ca_signing_role = f'hosts-{region_uuid}'
+
+    # The server key is strange, since this seems to be an unneeded abstraction. We have
+    # always called it 'dev' for some reason, so this is hardcoded in deccaxon and vouch now.
+
+    server_key = f'customers/{customer_uuid}/vault_servers/dev'
+
+    # Global across all regions
+
+    vault_server = consul.kv_get(f'{server_key}/url')
+
+    # The admin token has policies: [default kplane]
+    # This is independent of region.
+
+    admin_token = consul.kv_get(f'customers/{customer_uuid}/vault_servers/dev/admin_token')
+
+    # Construct a tree to place under the region services "vouch" section
+
+    vault_tree = {
+        'url': vault_server,
+        'server_key': server_key,
+    }
+
+    vault_servers_tree = {
+        'dev': {
+            'admin_token': admin_token,
+            'url': vault_server,
+        }
+    }
+
+    # these were in vouch_tree, but they are created at the end of this function
+    # 'ca_signing_role': ca_signing_role,
+    # 'host_signing_token': host_signing_token,
+
+    vouch_tree = {
+        'ca_common_name': ca_common_name,
+        'ca_name': ca_name,
+        'vault': vault_tree,
+        'vault_servers': vault_servers_tree,
+    }
+
+    full_tree = { 'customers': { customer_uuid: { 'regions': { region_uuid: { 'services': { 'vouch': vouch_tree }}}}}}
+    consul.kv_put_dict(full_tree)
+
+    # The earlier, legacy host_signing_token had policies: [default hosts-{customer_uuid}]
+    # But this has region-specific rules in it so it must be at the region level.
+    # Instead, generate a new token and policy:
+
+    vault = get_vault_admin_client(consul, customer_uuid)
+    rolename = create_host_signing_role(vault, consul, customer_uuid, region_uuid)
+    create_host_signing_token(vault, consul, customer_uuid, region_uuid, rolename)
+
+    return ca_name
+
+
 def get_vault_admin_client(consul, customer_uuid):
     region_uuid = os.environ['REGION_ID'] # to minimize signature changes
-    ca_name = consul.kv_get(f'customers/{customer_uuid}/regions/{region_uuid}/services/vouch/ca_name')
+
+    try:
+        ca_name = consul.kv_get(f'customers/{customer_uuid}/regions/{region_uuid}/services/vouch/ca_name')
+    except requests.HTTPError as e:
+        if e.response.status_code != 404:
+            raise
+        ca_name = fabricate_missing_data(consul, customer_uuid, region_uuid)
+
     ca_common_name = consul.kv_get(f'customers/{customer_uuid}/regions/{region_uuid}/services/vouch/ca_common_name')
 
     vault_server_key = consul.kv_get(f'customers/{customer_uuid}/regions/{region_uuid}/services/vouch/vault/server_key')
@@ -138,26 +246,27 @@ def get_vault_admin_client(consul, customer_uuid):
     return VaultCA(url, token, ca_name, ca_common_name)
 
 
-def create_host_signing_role(vault, consul, customer_id) -> str:
-    region_uuid = os.environ['REGION_ID']
-    rolename = 'hosts-%s' % customer_id
-    customer_key: str = f'customers/{customer_id}/regions/{region_uuid}/services/vouch/ca_signing_role'
+def create_host_signing_role(vault, consul, customer_id, region_id) -> str:
+    rolename = 'hosts-%s' % region_id
+    customer_key: str = f'customers/{customer_id}/regions/{region_id}/services/vouch/ca_signing_role'
     try:
         val = consul.kv_get(customer_key)
         LOG.debug('kv_get for %s returned: %s', customer_key, val)
-        return rolename
+        if val == rolename:
+            return rolename
     except HTTPError as err:
         if err.response.status_code != 404:
             LOG.error('cannot do kv_get on %s', customer_key, exc_info=err)
             raise err
-        vault.create_signing_role(rolename)
-        consul.kv_put(customer_key, rolename)
-        return rolename
+    # either a) the signing role hasn't been created, or b) it has a customer-level one
+    # older signing roles were hosts-{customer_id} not hosts-{region_id}
+    vault.create_signing_role(rolename)
+    consul.kv_put(customer_key, rolename)
+    return rolename
 
 
-def create_host_signing_token(vault, consul, customer_id, rolename, token_rolename='vouch-hosts'):
-    region_uuid = os.environ['REGION_ID']
-    policy_name = 'hosts-%s' % customer_id
+def create_host_signing_token(vault, consul, customer_id, region_uuid, rolename, token_rolename='vouch-hosts'):
+    policy_name = 'hosts-%s' % region_uuid
     customer_vault_url: str = f'customers/{customer_id}/regions/{region_uuid}/services/vouch/vault/url'
     customer_vault_hsk: str = f'customers/{customer_id}/regions/{region_uuid}/services/vouch/vault/host_signing_token'
     try:
@@ -183,6 +292,10 @@ def parse():
     return args, consul
 
 def new_token(consul, customer_id):
+    # obtain the region_id from the environment. We do not want to change the
+    # signature of this function since it is called from outside.
+    region_id = os.environ['REGION_ID']
+
     vault = get_vault_admin_client(consul, customer_id)
-    rolename = create_host_signing_role(vault, consul, customer_id)
-    create_host_signing_token(vault, consul, customer_id, rolename)
+    rolename = create_host_signing_role(vault, consul, customer_id, region_id)
+    create_host_signing_token(vault, consul, customer_id, region_id, rolename)

--- a/vouch/controllers/sign.py
+++ b/vouch/controllers/sign.py
@@ -35,9 +35,12 @@ class CAController(RestController):
             resp = self._vault.get_ca()
             pecan.response.status = 200
             pecan.response.json = resp.json()['data']
+            LOG.info('status: 200')
         except requests.HTTPError as e:
             pecan.response.status = e.response.status_code
             pecan.response.json = e.response.json()
+            LOG.info('status: %s', e.response.status_code)
+            LOG.info('response json: %s', e.response.json())
         return pecan.response
 
     @expose('json')
@@ -59,9 +62,12 @@ class CAController(RestController):
             resp_json['new'] = resp_new.json()['data']
             pecan.response.status = 200
             pecan.response.json = resp_json
+            LOG.info('status: 200')
         except requests.HTTPError as e:
             pecan.response.status = e.response.status_code
             pecan.response.json = e.response.json()
+            LOG.info('status: %s', e.response.status_code)
+            LOG.info('response json: %s', e.response.json())
         return pecan.response
 
 
@@ -106,9 +112,12 @@ class CertController(RestController):
                                             common_name, ip_sans, alt_names, ttl)
                 pecan.response.json = resp.json()['data']
                 pecan.response.status = 200
+                LOG.info('status: 200')
             except requests.HTTPError as e:
                 pecan.response.status = e.response.status_code
                 pecan.response.json = e.response.json()
+                LOG.info('status: %s', e.response.status_code)
+                LOG.info('response json: %s', e.response.json())
 
         return pecan.response
 


### PR DESCRIPTION
… we can

Originally there lived a single "vouch" section at the customer level. It was written at a time
when we supported only single regions, and when multi-region support was finally added, it would be
clobbered by subsequent region deployments. This meant hosts could only be onboarded to the
region most recently deployed.
Now there are "service/vouch" sections at the region level. Though we have a legacy vouch
section at the customer level, please mostly ignore it.
The ca_signing_role was originally hosts-{customer_name}. But in it we find a policy for a single
region, so we had a choice to either add additional regions to this policy, or create policies
for each region. The latter decision was taken.
Now each region has its own ca_signing_role as hosts-{region_name}.
Some old deployments are extant. There is now a fabricate_missing_data() function that creates
a region-level vouch configuration during upgrade. In doing so it might create new vault tokens.
I did not enjoy untangling this.
