### PR TITLE
[PMK-6700] Revert "Make vouch init-region scripts idempotent (#46)"

### DIFF
--- a/bin/common.py
+++ b/bin/common.py
@@ -9,7 +9,6 @@ import sys
 
 from argparse import ArgumentParser
 from firkinize.configstore.consul import Consul
-from requests import HTTPError
 from vaultlib.ca import VaultCA
 
 logging.basicConfig(level=logging.DEBUG)
@@ -138,39 +137,21 @@ def get_vault_admin_client(consul, customer_uuid):
     return VaultCA(url, token, ca_name, ca_common_name)
 
 
-def create_host_signing_role(vault, consul, customer_id) -> str:
+def create_host_signing_role(vault, consul, customer_id):
     rolename = 'hosts-%s' % customer_id
-    customer_key: str = f'customers/{customer_id}/vouch/ca_signing_role'
-    try:
-        val = consul.kv_get(customer_key)
-        LOG.debug('kv_get for %s returned: %s', customer_key, val)
-        return rolename
-    except HTTPError as err:
-        if err.response.status_code != 404:
-            LOG.error('cannot do kv_get on %s', customer_key, exc_info=err)
-            raise err
-        vault.create_signing_role(rolename)
-        consul.kv_put(customer_key, rolename)
-        return rolename
+    vault.create_signing_role(rolename)
+    consul.kv_put('customers/%s/vouch/ca_signing_role' % customer_id,
+                  rolename)
+    return rolename
 
 
 def create_host_signing_token(vault, consul, customer_id, rolename, token_rolename='vouch-hosts'):
     policy_name = 'hosts-%s' % customer_id
-    customer_vault_url: str = f'customers/{customer_id}/vouch/vault/url'
-    customer_vault_hsk: str = f'customers/{customer_id}/vouch/vault/host_signing_token'
-    try:
-        url = consul.kv_get(customer_vault_url)
-        LOG.debug('consul kv_get on %s returned: %s', customer_vault_url, url)
-        host_signing_token = consul.kv_get(customer_vault_hsk)
-        LOG.debug('consul kv_get on %s returned: %s', customer_vault_hsk, host_signing_token)
-    except HTTPError as err:
-        if err.response.status_code != 404:
-            LOG.error('cannot perform consul operation', exc_info=err)
-            raise err
-        vault.create_vouch_token_policy(rolename, policy_name)
-        token_info = vault.create_token(policy_name, token_role=token_rolename)
-        consul.kv_put(customer_vault_url, vault.addr)
-        consul.kv_put(customer_vault_hsk, token_info.json()['auth']['client_token'])
+    vault.create_vouch_token_policy(rolename, policy_name)
+    token_info = vault.create_token(policy_name, token_role=token_rolename)
+    consul.kv_put('customers/%s/vouch/vault/url' % customer_id, vault.addr)
+    consul.kv_put('customers/%s/vouch/vault/host_signing_token' % customer_id,
+                  token_info.json()['auth']['client_token'])
 
 
 def parse():


### PR DESCRIPTION
This reverts commit bc58e8b7139832980a220b39ad66908b5d72d1e9.

## ISSUE 
[https://platform9.atlassian.net/browse/PMK-6700?atlOrigin=eyJpIjoiODkwNGFkMDA1OTYzNDExYTgyYzBjYThjN2E5OTkyYTciLCJwIjoiaiJ9](https://platform9.atlassian.net/browse/PMK-6700?atlOrigin=eyJpIjoiODkwNGFkMDA1OTYzNDExYTgyYzBjYThjN2E5OTkyYTciLCJwIjoiaiJ9)

## TESTING NOTES
**Manual**
With image containing reverted changes we can observe that token is renewed .
 
 **Before**
```
➜  ~ git:(main) ✗ export KUBECONFIG=Downloads/general-cicd-kubeconfig\ \(6\).yaml                          
➜  ~ git:(main) ✗ kubectl get ns | grep 3944456                       
test-du-qbert-bare-os-u20-3944456        Active   11m
➜  ~ git:(main) ✗ kubectl get po -n test-du-qbert-bare-os-u20-3944456 | grep vouch
vouch-keystone-c478989b9-9ltx9                2/2     Running     0               4m19s
vouch-keystone-init-tvm6v                     0/1     Completed   0               4m30s
vouch-noauth-9b56d9b88-qtzj6                  3/3     Running     0               4m19s
➜  ~ git:(main) ✗ kubectl logs -n test-du-qbert-bare-os-u20-3944456 vouch-noauth-9b56d9b88-qtzj6   >> oldvouch.log
Defaulted container "vouch-noauth" out of: vouch-noauth, socat18558, socat28558
➜  ~ git:(main) ✗ kubectl get po -n test-du-qbert-bare-os-u20-3944456 | grep vault                                
pf9-vault-5cf4bcf7b7-dzncj                    2/2     Running     0               4m57s
pf9-vault-init-tph7t                          0/1     Completed   0               6m19s
➜  ~ git:(main) ✗ kubectl exec -it -n test-du-qbert-bare-os-u20-3944456  pf9-vault-5cf4bcf7b7-dzncj  -- sh
Defaulted container "vault" out of: vault, socat18200
/ # consul kv get customers/$CUSTOMER_ID/vouch/vault/host_signing_token
hvs.CAESIGx1J1mdGrPW6RiLAhSN7LT8czjCi4bElMlQgv-ZLlKCGh4KHGh2cy56czN5cXdVUG9JZDNjb1lzaElETDEzMUk
/ # 
/ # exit
➜  ~ git:(main) ✗ kubectl get cronjobs -n test-du-qbert-bare-os-u20-3944456 
NAME                SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
vouch-renew-token   0 0 */20 * *   False     0        <none>          6m
➜  ~ git:(main) ✗ kubectl get cronjobs -n test-du-qbert-bare-os-u20-3944456 vouch-renew-token -oyaml | grep image
            image: quay.io/platform9/vouch:5.12.2-596
            imagePullPolicy: IfNotPresent
          imagePullSecrets:
```
**After**
```
➜  ~ git:(main) ✗ kubectl edit cronjobs -n test-du-qbert-bare-os-u20-3944456 vouch-renew-token
cronjob.batch/vouch-renew-token edited
➜  ~ git:(main) ✗ kubectl get cronjobs -n test-du-qbert-bare-os-u20-3944456 vouch-renew-token -oyaml | grep image
            image: quay.io/platform9/vouch:5.12.2-631
            imagePullPolicy: IfNotPresent
          imagePullSecrets:
➜  ~ git:(main) ✗ kubectl create job --from=cronjob/vouch-renew-token vouch-renew-token-manual-1 -n test-du-qbert-bare-os-u20-3944456
job.batch/vouch-renew-token-manual-1 created
➜  ~ git:(main) ✗ kubectl get po -n test-du-qbert-bare-os-u20-3944456 | grep vouch                               
vouch-keystone-c478989b9-9ltx9                2/2     Running     0               7m29s
vouch-keystone-init-tvm6v                     0/1     Completed   0               7m40s
vouch-noauth-9b56d9b88-qtzj6                  3/3     Running     0               7m29s
vouch-renew-token-manual-1-4s797              0/1     Completed   0               25s
➜  ~ git:(main) ✗ kubectl logs -n test-du-qbert-bare-os-u20-3944456 vouch-renew-token-manual-1-4s797 > newvouch.log
➜  ~ git:(main) ✗ kubectl exec -it -n test-du-qbert-bare-os-u20-3944456  pf9-vault-5cf4bcf7b7-dzncj  -- sh   
Defaulted container "vault" out of: vault, socat18200
/ # consul kv get customers/$CUSTOMER_ID/vouch/vault/host_signing_token
hvs.CAESICjyTMW9r0Ni1KJeeVlI9_w4OD7eQjL_ciL7uk7aqLCyGh4KHGh2cy5uUlB1OXpXc1JsNUdoYzZOTEdWanpWVXQ
/ # 
```