### PR TITLE
stdout logging: pcd-1085

### DIFF
--- a/container/etc/supervisord-keystone.conf
+++ b/container/etc/supervisord-keystone.conf
@@ -5,7 +5,7 @@
 logfile=/var/log/supervisord.log
 logfile_maxbytes=50MB
 logfile_backups=10
-loglevel=debug
+loglevel=info
 pidfile=/var/run/supervisord.pid
 nodaemon=true
 minfds=1024
@@ -27,13 +27,15 @@ autorestart=true
 startretries=99
 startsecs=1
 redirect_stderr=true
-stdout_logfile=/var/log/vouch.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 user=root
 
 [program:confd]
 command=/usr/bin/confd -backend consul -node %(ENV_CONFIG_HOST_AND_PORT)s -scheme %(ENV_CONFIG_SCHEME)s -watch -prefix /customers/%(ENV_CUSTOMER_ID)s -auth-token %(ENV_CONSUL_HTTP_TOKEN)s
 redirect_stderr=true
-stdout_logfile=/var/log/confd.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 autorestart=true
 startretries=99
 startsecs=1

--- a/container/scripts/readiness_checks.sh
+++ b/container/scripts/readiness_checks.sh
@@ -5,6 +5,7 @@ VAULT_TOKEN=$(grep vault_token /etc/vouch/vouch-keystone.conf | awk '{ print $2 
 
 TOKEN_HEALTH_STATUS=$(curl -o /dev/null -s -w "%{http_code}\n" --header "X-Vault-Token: $VAULT_TOKEN" $VAULT_URL/v1/auth/token/lookup-self)
 
+echo "readiness checks: $TOKEN_HEALTH_STATUS" > /proc/1/fd/1
 if [ $TOKEN_HEALTH_STATUS != "200" ]; then
 	echo "Service is not healthy, received $TOKEN_HEALTH_STATUS" > /proc/1/fd/1
 	exit 1

--- a/container/scripts/readiness_checks.sh
+++ b/container/scripts/readiness_checks.sh
@@ -6,6 +6,7 @@ VAULT_TOKEN=$(grep vault_token /etc/vouch/vouch-keystone.conf | awk '{ print $2 
 TOKEN_HEALTH_STATUS=$(curl -o /dev/null -s -w "%{http_code}\n" --header "X-Vault-Token: $VAULT_TOKEN" $VAULT_URL/v1/auth/token/lookup-self)
 
 if [ $TOKEN_HEALTH_STATUS != "200" ]; then
+	echo "Service is not healthy, received $TOKEN_HEALTH_STATUS" > /proc/1/fd/1
 	exit 1
 fi
 

--- a/container/scripts/readiness_checks.sh
+++ b/container/scripts/readiness_checks.sh
@@ -5,7 +5,6 @@ VAULT_TOKEN=$(grep vault_token /etc/vouch/vouch-keystone.conf | awk '{ print $2 
 
 TOKEN_HEALTH_STATUS=$(curl -o /dev/null -s -w "%{http_code}\n" --header "X-Vault-Token: $VAULT_TOKEN" $VAULT_URL/v1/auth/token/lookup-self)
 
-echo "readiness checks: $TOKEN_HEALTH_STATUS" > /proc/1/fd/1
 if [ $TOKEN_HEALTH_STATUS != "200" ]; then
 	echo "Service is not healthy, received $TOKEN_HEALTH_STATUS" > /proc/1/fd/1
 	exit 1


### PR DESCRIPTION
all supervisord processes write to pid 1 stdout, even failed health checks show up in kubectl logs