### PR TITLE
[PMK-5700] [PMK-6736] Expose vouch token expiry ttl

### DIFF
--- a/vouch/controllers/metrics_controller.py
+++ b/vouch/controllers/metrics_controller.py
@@ -1,4 +1,5 @@
 
+import os
 import logging
 import pecan
 import time
@@ -11,11 +12,19 @@ from pecan.rest import RestController
 from vouch.conf import CONF
 from vaultlib.ca import VaultCA
 from prometheus_client import generate_latest, Gauge
+from datetime import datetime, timezone
+from dateutil import parser
+from firkinize.configstore.consul import Consul
+
 
 g_ca_cert_refresh_needed = Gauge('refresh_needed', 'Is CA cert refresh needed?')
 g_ca_cert_expiry_time = Gauge('cert_expiry_time', 'Time in seconds till CA cert expires')
+g_host_signing_token_expiry = Gauge('vouch_host_signing_token_expiry', 'Time in seconds till host signing token expires')
 
 
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s - %(name)s - %(threadName)s - '
+                           '%(levelname)s - %(message)s')
 LOG = logging.getLogger(__name__)
 
 def query_vault(vault):
@@ -23,7 +32,7 @@ def query_vault(vault):
     cert = resp.json()['data']['certificate']
     c=x509.load_pem_x509_certificate(cert.encode('utf-8'),default_backend())
     return c
-    
+
 class  MetricsController(RestController):
     def __init__(self):
         self._vault = VaultCA(
@@ -36,6 +45,50 @@ class  MetricsController(RestController):
         cert = query_vault(self._vault)
         self.cert_expiration_time = cert.not_valid_after
 
+        # For querying host signing token expiry
+        self.vault_token = CONF['vault_token']
+        self.host_signing_token_expiry = None
+        self.host_signing_token_last_update_time = time.time()
+        self.customer_uuid = os.environ['CUSTOMER_ID']
+        config_url = os.environ.get('CONSUL_HTTP_ADDR', None)
+        token = os.environ.get('CONSUL_HTTP_TOKEN', None)
+        self.consul = Consul(config_url, token=token)
+    
+    def get_host_signing_token_expiry(self):
+        current_time = time.time()
+    
+        try:
+            vault_url = self.consul.kv_get(f'customers/{self.customer_uuid}/vouch/vault/url')
+            host_signing_token = self.consul.kv_get(f'customers/{self.customer_uuid}/vouch/vault/host_signing_token')
+
+            headers = {'X-Vault-Token': host_signing_token}
+
+            LOG.info("Sending request to Vault token lookup-self API...")
+            response = requests.get(f'{vault_url}/v1/auth/token/lookup-self', headers=headers)
+
+            if response.status_code != 200:
+                LOG.error(f"Vault token lookup failed: {response.status_code}, {response.text}")
+                return None
+
+            token_info = response.json()
+            expire_str = token_info['data'].get('expire_time')
+
+            if expire_str:
+                expire_time = parser.isoparse(expire_str)
+                current_time = datetime.now(timezone.utc)
+                ttl_seconds = int((expire_time - current_time).total_seconds())
+                self.host_signing_token_expiry = ttl_seconds
+                self.host_signing_token_last_update_time = current_time
+                LOG.info(f"Parsed expire time: {expire_time}")
+                self.host_signing_token_last_update_time = current_time
+            else:
+                LOG.info("expire_time not found in Vault response.")
+
+        except Exception as e:
+                LOG.error(f"Error while fetching host signing token expiry: {e}")
+                return None
+
+        return self.host_signing_token_expiry
 
     def get_cert_expiration_time(self):
         current_time = time.time()
@@ -52,9 +105,11 @@ class  MetricsController(RestController):
         """
         try:
             self.get_cert_expiration_time()
+            host_signing_token_expiry = self.get_host_signing_token_expiry()
             ca_cert_expiry_time = time.mktime(self.cert_expiration_time.timetuple())
             current_time = time.time()
             g_ca_cert_expiry_time.set(int(ca_cert_expiry_time))
+            g_host_signing_token_expiry.set(host_signing_token_expiry)
             if ca_cert_expiry_time - current_time < CONF['refresh_period']:
                 g_ca_cert_refresh_needed.set(1)
             else:

--- a/vouch/controllers/metrics_controller.py
+++ b/vouch/controllers/metrics_controller.py
@@ -21,7 +21,6 @@ g_ca_cert_refresh_needed = Gauge('refresh_needed', 'Is CA cert refresh needed?')
 g_ca_cert_expiry_time = Gauge('cert_expiry_time', 'Time in seconds till CA cert expires')
 g_host_signing_token_expiry = Gauge('vouch_host_signing_token_expiry', 'Time in seconds till host signing token expires')
 
-
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s - %(name)s - %(threadName)s - '
                            '%(levelname)s - %(message)s')
@@ -76,7 +75,7 @@ class  MetricsController(RestController):
             if expire_str:
                 expire_time = parser.isoparse(expire_str)
                 current_time = datetime.now(timezone.utc)
-                ttl_seconds = int((expire_time - current_time).total_seconds())
+                ttl_seconds = (expire_time - current_time).total_seconds()
                 self.host_signing_token_expiry = ttl_seconds
                 self.host_signing_token_last_update_time = current_time
                 LOG.info(f"Parsed expire time: {expire_time}")
@@ -109,7 +108,7 @@ class  MetricsController(RestController):
             ca_cert_expiry_time = time.mktime(self.cert_expiration_time.timetuple())
             current_time = time.time()
             g_ca_cert_expiry_time.set(int(ca_cert_expiry_time))
-            g_host_signing_token_expiry.set(host_signing_token_expiry)
+            g_host_signing_token_expiry.set(int(host_signing_token_expiry or 0))
             if ca_cert_expiry_time - current_time < CONF['refresh_period']:
                 g_ca_cert_refresh_needed.set(1)
             else:


### PR DESCRIPTION
## ISSUES:
https://platform9.atlassian.net/browse/PMK-5700
https://platform9.atlassian.net/browse/PMK-6736

## SUMMARY:
exposed `host_signing_token` expiry ttl from vouch for prometheus.

## TESTING NOTES:
<img width="1414" height="426" alt="Screenshot 2025-09-01 at 12 51 35 AM" src="https://github.com/user-attachments/assets/a82514f7-0f0b-47d4-be76-1d4652a522a5" />

in case of error/expired:
<img width="1406" height="339" alt="Screenshot 2025-09-03 at 12 06 59 PM" src="https://github.com/user-attachments/assets/64ca66d0-ce95-49cc-8236-8038c9c33653" />

